### PR TITLE
Fix cross-compilation in the Docker build

### DIFF
--- a/src/SecretsMocker/SecretsMocker/Dockerfile
+++ b/src/SecretsMocker/SecretsMocker/Dockerfile
@@ -1,20 +1,16 @@
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
-WORKDIR /app
-EXPOSE 80
-
-
 FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+
 WORKDIR '/src/SecretsMocker/SecretsMocker'
 COPY . .
 RUN dotnet restore './SecretsMocker.csproj'
 RUN dotnet build './SecretsMocker.csproj' -c Release -o /app/build --no-restore
 
-
 FROM build AS publish
+
 RUN dotnet publish './SecretsMocker.csproj' --no-restore -c Release -o /app/publish /p:UseAppHost=false --self-contained false
 
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 as final
 
-FROM base AS final
 WORKDIR /app
 COPY --from=publish /app/publish .
 ENTRYPOINT ["dotnet", "SecretsMocker.dll"]


### PR DESCRIPTION
The reason the app wasn't launching on arm64 was because the _base_ image (which the _final_ image was based off of) was using the host's platform. Instead, you want the platform of the target, which you get for free if you don't specify a `--platform` argument for the `FROM` command.

Here's it working while emulating arm64 on my amd64 desktop:

![image](https://github.com/LanceMcCarthy/akeyless-web-target/assets/573979/0ac672fa-fe04-4f0b-9854-b32ab43470fc)
